### PR TITLE
added api request count event data generation

### DIFF
--- a/ceilometermiddleware/swift.py
+++ b/ceilometermiddleware/swift.py
@@ -366,7 +366,7 @@ class Swift(object):
                     name='storage.objects.outgoing.bytes', unit='B')))
 
         # api call
-        request_metric_name = Swift.get_request_metric_name(method.lower())
+        request_metric_name = self.get_request_metric_name(method.lower())
         if request_metric_name:
             event.add_measurement(cadf_measurement.Measurement(
                 result=1,


### PR DESCRIPTION
made changes in the code to send the event data in case of api calls . One of the following metric will be added to the ceilometer event based on the request type
```
storage.objects.get.count
storage.objects.post.count
storage.objects.put.count
storage.objects.delete.count
storage.objects.head.count
```