### PR TITLE
added check for empty reseller prefix

### DIFF
--- a/ceilometermiddleware/swift.py
+++ b/ceilometermiddleware/swift.py
@@ -334,9 +334,14 @@ class Swift(object):
                     header.upper())
 
         # build object store details
-        target = cadf_resource.Resource(
-            typeURI='service/storage/object',
-            id=account.partition(self.reseller_prefix)[2] or path)
+        if self.reseller_prefix:
+            target = cadf_resource.Resource(
+                typeURI='service/storage/object',
+                id=account.partition(self.reseller_prefix)[2] or path)
+        else:
+            target = cadf_resource.Resource(
+                typeURI='service/storage/object',
+                id=account)
         target.metadata = resource_metadata
         target.action = method.lower()
 


### PR DESCRIPTION
ISSUE: setting reseller_prefix to empty string throws error
FIX : Added a check for empty reseller_prefix